### PR TITLE
Prepare for compatibility with GraphDB 11 - Spring 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,9 +184,14 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.github.soc</groupId>
+			<groupId>org.ogc-schemas</groupId>
 			<artifactId>ogc-tools-gml-jts</artifactId>
-			<version>1.1.90</version>
+			<version>4.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>4.0.5</version>
 		</dependency>
 
 		<!-- For Geotoolkit's cache. We need to have it outside the plugin classloader so it must be packaged in the dist -->

--- a/src/main/java/com/ontotext/trree/geosparql/GeoSparqlPlugin.java
+++ b/src/main/java/com/ontotext/trree/geosparql/GeoSparqlPlugin.java
@@ -15,7 +15,7 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 /**
  * GeoSPARQL index/query plugin.

--- a/src/main/java/com/ontotext/trree/geosparql/gml/GmlConverter.java
+++ b/src/main/java/com/ontotext/trree/geosparql/gml/GmlConverter.java
@@ -8,10 +8,10 @@ import org.locationtech.jts.geom.Geometry;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.operation.MathTransform;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 import java.io.StringReader;
 import java.io.StringWriter;
 

--- a/src/main/java/com/ontotext/trree/geosparql/gml/GmlSerializer.java
+++ b/src/main/java/com/ontotext/trree/geosparql/gml/GmlSerializer.java
@@ -8,7 +8,7 @@ import com.useekm.types.exception.InvalidGeometryException;
 import org.eclipse.rdf4j.model.IRI;
 import org.locationtech.jts.geom.Geometry;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 /**
  * GML serializer according to what Useekm expects.


### PR DESCRIPTION
Replace the javax with the jakarta namespace, add org.ogc-schemas instead of io.github.soc because of jakarta compatibility, and add the implementation of JAXB.